### PR TITLE
Declared content module client side interface, SendMessage data structures, and factory.

### DIFF
--- a/Content/Client/ContentClientFactory.cs
+++ b/Content/Client/ContentClientFactory.cs
@@ -1,0 +1,15 @@
+using System;
+namespace Content
+{
+    public class ContentClientFactory
+    {
+        private ContentClientFactory() { }
+        private static IContentClient _instance;
+
+        public static void setUser(int userId);
+        public static IContentClient getInstance()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Content/Client/IContentClient.cs
+++ b/Content/Client/IContentClient.cs
@@ -1,0 +1,12 @@
+namespace Content
+{
+    public interface IContentClient
+    {
+        void CSend(SendMessageData toSend);
+        void CDownload(int messageId, string savePath);
+        void CMarkStar(int messageId);
+        void CUpdateChat(int messageId, string newMessage);
+        void CSubscribe(IContentListener subscriber);
+        Thread CGetThread(int threadId);
+    }
+}

--- a/Content/IContentListener.cs
+++ b/Content/IContentListener.cs
@@ -1,6 +1,6 @@
 namespace Content
 {
-    interface IContentListener
+    public interface IContentListener
     {
         void OnMessage(ReceiveMessageData messageData);
         void OnAllMessages(List<Thread> allMessages);

--- a/Content/Models/Enums.cs
+++ b/Content/Models/Enums.cs
@@ -1,11 +1,11 @@
 namespace Content
 {
-    enum MessageType
+    public enum MessageType
     {
         File,
         Chat
     }
-    enum MessageEvent
+    public enum MessageEvent
     {
         Update,
         NewMessage,

--- a/Content/Models/Enums.cs
+++ b/Content/Models/Enums.cs
@@ -1,0 +1,15 @@
+namespace Content
+{
+    enum MessageType
+    {
+        File,
+        Chat
+    }
+    enum MessageEvent
+    {
+        Update,
+        NewMessage,
+        Star,
+        Download
+    }
+}

--- a/Content/Models/ReceiveMessageData.cs
+++ b/Content/Models/ReceiveMessageData.cs
@@ -1,16 +1,16 @@
 using System;
 namespace Content
 {
-    class ReceiveMessageData
+    public class ReceiveMessageData
     {
-        MessageEvent messageEvent; // will be one of update, new message or star
-        MessageType messageType; // enum/string indicating file or chat
-        string message; // message if message type is chat / filename and size if file
-        int messageId;
-        int senderId;
-        int[] receiverIds; // list of receiver ids
-        int replyThreadId; // special value (-1) if message not part of any existing thread otherwise thread id of thread to which the message belongs
-        DateTime sentTime; // time at which message was sent
-        bool starred; // value indicating whether a message is to be included in the summary
+        public MessageEvent messageEvent; // will be one of update, new message or star
+        public MessageType messageType; // enum/string indicating file or chat
+        public string message; // message if message type is chat / filename and size if file
+        public int messageId;
+        public int senderId;
+        public int[] receiverIds; // list of receiver ids
+        public int replyThreadId; // special value (-1) if message not part of any existing thread otherwise thread id of thread to which the message belongs
+        public DateTime sentTime; // time at which message was sent
+        public bool starred; // value indicating whether a message is to be included in the summary
     }
 }

--- a/Content/Models/ReceiveMessageData.cs
+++ b/Content/Models/ReceiveMessageData.cs
@@ -1,20 +1,8 @@
+using System;
 namespace Content
 {
     class ReceiveMessageData
     {
-        enum MessageType
-        {
-            File,
-            Chat
-        }
-        enum MessageEvent
-        {
-            Update,
-            NewMessage,
-            Star,
-            Download
-        }
-
         MessageEvent messageEvent; // will be one of update, new message or star
         MessageType messageType; // enum/string indicating file or chat
         string message; // message if message type is chat / filename and size if file

--- a/Content/Models/SendMessageData.cs
+++ b/Content/Models/SendMessageData.cs
@@ -1,0 +1,11 @@
+namespace Content
+{
+    public class SendMessageData
+    {
+        public MessageType messageType; // enum indicating file or chat
+        public string message; // message if chat, filepath if message type is File
+        public int receiverIds[]; // list of receiver ids
+        public int replyThreadId; // special value (-1) if message not part of any existing thread 
+                           // otherwise thread id of thread to which the message belongs
+    }
+}

--- a/Content/Models/Thread.cs
+++ b/Content/Models/Thread.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 namespace Content
 {
     class Thread

--- a/Content/Models/Thread.cs
+++ b/Content/Models/Thread.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 namespace Content
 {
-    class Thread
+    public class Thread
     {
-        List<ReceiveMessageData> msgList;
-        int threadId;
-        int numOfMessages;
-        DateTime creationTime;
+        public List<ReceiveMessageData> msgList;
+        public int threadId;
+        public int numOfMessages;
+        public DateTime creationTime;
     }
 }

--- a/Content/server/ContentServerFactory.cs
+++ b/Content/server/ContentServerFactory.cs
@@ -1,8 +1,8 @@
 namespace Content
 {
-    class ContentServerFactory
+    public class ContentServerFactory
     {
-        static void setUser(int userId);
-        static IContentServer getInstance();
+        public static void setUser(int userId);
+        public static IContentServer getInstance();
     }
 }

--- a/Content/server/IContentServer.cs
+++ b/Content/server/IContentServer.cs
@@ -1,6 +1,6 @@
-namespace  Content
+namespace Content
 {
-    interface IContentServer
+    public interface IContentServer
     {
         void SSubscribe(IContentListener subscriber);
         List<Thread> SGetAllMessages();


### PR DESCRIPTION
Declared the IContentClient interface.
Defined the SendMessageData class which defines a data structure for sending a message using the IContentClient interface.
Moved Enums outside of the ReceiveMessageData class into Enums.cs file.
Created the ContentClientFactory class that returns an implementation of the IContentClient interface. Currently raises a NotImplementedException.