### PR TITLE
Fixed Receiver IDs intersection function

### DIFF
--- a/Content/Client/ContentClient.cs
+++ b/Content/Client/ContentClient.cs
@@ -171,7 +171,8 @@ namespace Content
                 ReceiveMessageData precursorMessage = RetrieveMessage(toSend.ReplyMsgId);
                 if (precursorMessage is null)
                     throw new ArgumentException("Invalid reply message id: Message being replied to doesn't exist");
-                toSend.ReceiverIds = ReceiverIntersection(precursorMessage.ReceiverIds, toSend.ReceiverIds);
+                // sender id of the precursor also has to be counted in the intersection
+                toSend.ReceiverIds = ReceiverIntersection(precursorMessage.ReceiverIds, precursorMessage.SenderId, toSend.ReceiverIds);
             }
                 
             switch (toSend.Type)
@@ -561,16 +562,19 @@ namespace Content
                 throw new ArgumentException("Invalid reply message id and thread id combination: Message being replied to is part of a different thread than the reply");
         }
 
-        private int[] ReceiverIntersection(int[] receivers1, int[] receivers2)
+        private int[] ReceiverIntersection(int[] precursorReceiverIds, int precursorSenderId, int[] replyReceiverIds)
         {
             // special case for empty array, which means broadcast, so the intersection is just the other array
-            if (receivers1.Length == 0)
-                return receivers2;
-            if (receivers2.Length == 0)
-                return receivers1;
+            if (precursorReceiverIds.Length == 0)
+                return replyReceiverIds;
+
+            // the sender should also be counted as one of the receivers of the precursor, so append it to the precursor receiver ids
+            precursorReceiverIds = precursorReceiverIds.Concat(new int[] { precursorSenderId }).ToArray();
+            if (replyReceiverIds.Length == 0)
+                return precursorReceiverIds; ; 
 
             // take intersection
-            int[] intersection = receivers1.Intersect(receivers2).ToArray();
+            int[] intersection = precursorReceiverIds.Intersect(replyReceiverIds).ToArray();
             // if intersection is empty, it means that the list of recievers of the first message and the reply are disjoint
             // which means the reply can't be sent to anyone, in which case we raise an error
             if (intersection.Length > 0)


### PR DESCRIPTION
The sender id is now also counted as a recipient of the precursor message when finding the intersection of receiver ids for it and its reply